### PR TITLE
[BUG] html_entity_decode should happen first

### DIFF
--- a/src/Mime/Html.php
+++ b/src/Mime/Html.php
@@ -24,7 +24,7 @@ class Html implements MimeInterface {
 
     public function extract(array $replacements, UrlInterface $url) {
         if (preg_match('#<title[^>]*>(.*?)</title>#is', $url->getBody(), $match)) {
-            $replacements['%composed-title%'] = $replacements['%title%'] = html_entity_decode(preg_replace('/[\s\v]+/', ' ', trim($match[1])));
+            $replacements['%composed-title%'] = $replacements['%title%'] = preg_replace('/[\s\v]+/', ' ', trim(html_entity_decode($match[1])));
         }
 
         return $replacements;


### PR DESCRIPTION
Some control characters (like the new line) will break Phergie when trying to process the event. Decoding the string first allows them to be removed.

The bug happened on [this url](https://twitter.com/Sheldon_Jokes/status/458591047531364354), which has new lines encoded as &#10; decoding the string first successfully fixed it.
