### PR TITLE
Add hostUrlEmitsOnly config option

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,10 @@ return array(
         // configuration
         new \WyriHaximus\Phergie\Plugin\Url\Plugin(array(
             // All configuration is optional
+            
+            'hostUrlEmitsOnly' = false // url.host.(all|<host>) emits only, no further URL handling / shortening
+            
+            // or
 
             'handler' => new \WyriHaximus\Phergie\Plugin\Url\DefaultUrlHandler(), // URL handler that creates a formatted message based on the URL
 

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -36,6 +36,10 @@ class Plugin extends AbstractPlugin implements LoopAwareInterface
      * @var UrlHandlerInterface
      */
     protected $shortingTimeout = 15;
+    /**
+     * @var bool
+     */
+    protected $hostUrlEmitsOnly = false;
 
     /**
      * @var LoopInterface
@@ -64,6 +68,9 @@ class Plugin extends AbstractPlugin implements LoopAwareInterface
         }
         if (isset($config['shortingTimeout'])) {
             $this->shortingTimeout = $config['shortingTimeout'];
+        }
+        if (isset($config['hostUrlEmitsOnly'])) {
+            $this->hostUrlEmitsOnly = boolval($config['hostUrlEmitsOnly']);
         }
     }
 
@@ -140,7 +147,7 @@ class Plugin extends AbstractPlugin implements LoopAwareInterface
             $this->logDebug('[' . $requestId . ']Corrected url: ' . $url);
         }
 
-        if ($this->emitUrlEvents($requestId, $url, $event, $queue)) {
+        if ($this->emitUrlEvents($requestId, $url, $event, $queue) && !$this->hostUrlEmitsOnly) {
             $this->logDebug('[' . $requestId . ']Emitting: http.request');
             $this->emitter->emit('http.request', array($this->createRequest($requestId, $url, $event, $queue)));
         }


### PR DESCRIPTION
Currently there is no sane way to turn off the URL shortening / handling if one just wants to use the emits (f.e. for the youtube plugin). This pull requests add a config option for that.