### PR TITLE
Fix a bug that caused an infinite loop if you PM a URL to bot.

### DIFF
--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -285,8 +285,6 @@ class Plugin extends AbstractPlugin implements LoopAwareInterface
     protected function sendMessage(Url $url, UserEvent $event, EventQueue $queue)
     {
         $message = $this->getHandler()->handle($url);
-        foreach ($event->getTargets() as $target) {
-            $queue->ircPrivmsg($target, $message);
-        }
+        $queue->ircPrivmsg($event->getSource(), $message);
     }
 }

--- a/tests/PluginTest.php
+++ b/tests/PluginTest.php
@@ -117,7 +117,7 @@ class PluginTest extends \PHPUnit_Framework_TestCase
         Phake::when($plugin)->getHandler()->thenReturn($handler);
 
         $event = Phake::mock('Phergie\Irc\Event\UserEvent');
-        Phake::when($event)->getTargets()->thenReturn(array($target));
+        Phake::when($event)->getSource()->thenReturn($target);
 
         $queue = Phake::mock('Phergie\Irc\Bot\React\EventQueue');
 


### PR DESCRIPTION
If the target of the message is the bot, then it replies to itself. Then the reply triggers the URL plugin again. Bot loops until it gets disconnected for "Excess Flood".